### PR TITLE
Change the docker image to use ubuntu:20.04

### DIFF
--- a/src/demo/remove_comments/config.vsh.yaml
+++ b/src/demo/remove_comments/config.vsh.yaml
@@ -24,5 +24,5 @@ functionality:
     path: test.sh
 platforms:
   - type: docker
-    image: bash:4.0
+    image: ubuntu:20.04
   - type: nextflow


### PR DESCRIPTION
Latest Nextflow calls /bin/bash explicitly while in the bash image it is located at /usr/local/bin/bash. Without this change, the nextflow execution throws an error.